### PR TITLE
Add asynchronous API

### DIFF
--- a/Rock.Encryption/Async/AsAsyncExtension.cs
+++ b/Rock.Encryption/Async/AsAsyncExtension.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// Defines an extension method to convert <see cref="ICrypto"/> to <see cref="IAsyncCrypto"/>.
+    /// </summary>
+    public static class AsAsyncExtension
+    {
+        private static readonly ConditionalWeakTable<ICrypto, IAsyncCrypto> _table = new ConditionalWeakTable<ICrypto, IAsyncCrypto>();
+
+        /// <summary>
+        /// Returns the input as <see cref="IAsyncCrypto"/>.
+        /// <para>If the <paramref name="crypto"/> parameter implements the <see cref="IAsyncCrypto"/>
+        /// interface, then it is cast and returned. If the <paramref name="crypto"/> parameter does
+        /// *not* implement the <see cref="IAsyncCrypto"/> interface, then an instance of
+        /// <see cref="SynchronousAsyncCrypto"/> is returned. Note that subsequent calls to this
+        /// method with the same instance of <see cref="ICrypto"/> will return the same instance of
+        /// <see cref="SynchronousAsyncCrypto"/>.</para>
+        /// </summary>
+        /// <param name="crypto">
+        /// An instance of <see cref="ICrypto"/> to be converted to <see cref="IAsyncCrypto"/>
+        /// </param>
+        /// <returns>
+        /// An instance of <see cref="IAsyncCrypto"/> that corresponds to the <paramref name="crypto"/> parameter.
+        /// </returns>
+        public static IAsyncCrypto AsAsync(this ICrypto crypto)
+        {
+            return crypto as IAsyncCrypto
+                ?? _table.GetValue(crypto, c => new SynchronousAsyncCrypto(c));
+        }
+    }
+}

--- a/Rock.Encryption/Async/IAsyncCrypto.cs
+++ b/Rock.Encryption/Async/IAsyncCrypto.cs
@@ -1,0 +1,102 @@
+﻿using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// Defines various asynchronous encryption and decryption methods.
+    /// </summary>
+    public interface IAsyncCrypto
+    {
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A task whose result represents the encrypted value as a string.</returns>
+        Task<string> EncryptAsync(string plainText, object keyIdentifier);
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A task whose result represents the decrypted value as a string.</returns>
+        Task<string> DecryptAsync(string cipherText, object keyIdentifier);
+
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A task whose result represents the encrypted value as a byte array.</returns>
+        Task<byte[]> EncryptAsync(byte[] plainText, object keyIdentifier);
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A task whose result represents the decrypted value as a byte array.</returns>
+        Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier);
+
+        /// <summary>
+        /// Asynchronously gets an instance of <see cref="IAsyncEncryptor"/> for the provided
+        /// encrypt key.
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>
+        /// A task whose result represents an object that can be used for encryption operations.
+        /// </returns>
+        Task<IAsyncEncryptor> GetEncryptorAsync(object keyIdentifier);
+
+        /// <summary>
+        /// Asynchronously ets an instance of <see cref="IAsyncDecryptor"/> for the provided
+        /// encrypt key.
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>
+        /// A task whose result represents an object that can be used for decryption operations.
+        /// </returns>
+        Task<IAsyncDecryptor> GetDecryptorAsync(object keyIdentifier);
+
+        /// <summary>
+        /// Returns a value indicating whether this instance of <see cref="ICrypto"/>
+        /// is able to handle the provided key identifier for an encrypt operation.
+        /// </summary>
+        /// <param name="keyIdentifier">The key identifier to check.</param>
+        /// <returns>
+        /// True, if this instance can handle the key identifier for an encrypt operation.
+        /// Otherwise, false.
+        /// </returns>
+        bool CanEncrypt(object keyIdentifier);
+
+        /// <summary>
+        /// Returns a value indicating whether this instance of <see cref="ICrypto"/>
+        /// is able to handle the provided key identifier for an decrypt operation.
+        /// </summary>
+        /// <param name="keyIdentifier">The key identifier to check.</param>
+        /// <returns>
+        /// True, if this instance can handle the key identifier for an encrypt operation.
+        /// Otherwise, false.
+        /// </returns>
+        bool CanDecrypt(object keyIdentifier);
+    }
+}

--- a/Rock.Encryption/Async/IAsyncDecryptor.cs
+++ b/Rock.Encryption/Async/IAsyncDecryptor.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// Defines methods for asynchronous decryption.
+    /// </summary>
+    public interface IAsyncDecryptor
+    {
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>A task whose result represents the decrypted value as a string.</returns>
+        Task<string> DecryptAsync(string cipherText);
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>A task whose result represents the decrypted value as a byte array.</returns>
+        Task<byte[]> DecryptAsync(byte[] cipherText);
+    }
+}

--- a/Rock.Encryption/Async/IAsyncEncryptor.cs
+++ b/Rock.Encryption/Async/IAsyncEncryptor.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// Defines methods for asynchronous encryption.
+    /// </summary>
+    public interface IAsyncEncryptor
+    {
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>A task whose result represents the encrypted value as a string.</returns>
+        Task<string> EncryptAsync(string plainText);
+
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>A task whose result represents the encrypted value as a byte array.</returns>
+        Task<byte[]> EncryptAsync(byte[] plainText);
+    }
+}

--- a/Rock.Encryption/Async/SynchronousAsyncCrypto.cs
+++ b/Rock.Encryption/Async/SynchronousAsyncCrypto.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// An implementation of <see cref="IAsyncCrypto"/> that delegates all functionality
+    /// to an instance of <see cref="ICrypto"/>. All tasks returned by its methods are
+    /// guaranteed to be either completed or faulted.
+    /// </summary>
+    public sealed class SynchronousAsyncCrypto : IAsyncCrypto
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SynchronousAsyncCrypto"/> class.
+        /// </summary>
+        /// <param name="crypto">
+        /// The instance of <see cref="ICrypto"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncCrypto"/>.
+        /// </param>
+        public SynchronousAsyncCrypto(ICrypto crypto)
+        {
+            Crypto = crypto;
+        }
+
+        /// <summary>
+        /// Gets the instance of <see cref="ICrypto"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncCrypto"/>.
+        /// </summary>
+        public ICrypto Crypto { get; }
+
+        /// <summary>
+        /// Synchronously encrypts the specified plain text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A completed task whose result represents the encrypted value as a string.</returns>
+        public Task<string> EncryptAsync(string plainText, object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<string>();
+            try
+            {
+                completion.SetResult(Crypto.Encrypt(plainText, keyIdentifier));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously decrypts the specified cipher text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A completed task whose result represents the decrypted value as a string.</returns>
+        public Task<string> DecryptAsync(string cipherText, object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<string>();
+            try
+            {
+                completion.SetResult(Crypto.Decrypt(cipherText, keyIdentifier));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously encrypts the specified plain text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A completed task whose result represents the encrypted value as a byte array.</returns>
+        public Task<byte[]> EncryptAsync(byte[] plainText, object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<byte[]>();
+            try
+            {
+                completion.SetResult(Crypto.Encrypt(plainText, keyIdentifier));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously decrypts the specified cipher text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>A completed task whose result represents the decrypted value as a byte array.</returns>
+        public Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<byte[]>();
+            try
+            {
+                completion.SetResult(Crypto.Decrypt(cipherText, keyIdentifier));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously gets an instance of <see cref="IAsyncEncryptor"/> for the provided
+        /// encrypt key.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>
+        /// A completed task whose result represents an object that can be used for encryption operations.
+        /// </returns>
+        public Task<IAsyncEncryptor> GetEncryptorAsync(object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<IAsyncEncryptor>();
+            try
+            {
+                completion.SetResult(new SynchronousAsyncEncryptor(Crypto.GetEncryptor(keyIdentifier)));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
+        /// encrypt key.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>
+        /// A completed task whose result represents an object that can be used for decryption operations.
+        /// </returns>
+        public Task<IAsyncDecryptor> GetDecryptorAsync(object keyIdentifier)
+        {
+            var completion = new TaskCompletionSource<IAsyncDecryptor>();
+            try
+            {
+                completion.SetResult(new SynchronousAsyncDecryptor(Crypto.GetDecryptor(keyIdentifier)));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance of <see cref="ICrypto"/>
+        /// is able to handle the provided key identifier for an encrypt operation.
+        /// </summary>
+        /// <param name="keyIdentifier">The key identifier to check.</param>
+        /// <returns>
+        /// True, if this instance can handle the key identifier for an encrypt operation.
+        /// Otherwise, false.
+        /// </returns>
+        public bool CanEncrypt(object keyIdentifier)
+        {
+            return Crypto.CanEncrypt(keyIdentifier);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance of <see cref="ICrypto"/>
+        /// is able to handle the provided key identifier for an decrypt operation.
+        /// </summary>
+        /// <param name="keyIdentifier">The key identifier to check.</param>
+        /// <returns>
+        /// True, if this instance can handle the key identifier for an encrypt operation.
+        /// Otherwise, false.
+        /// </returns>
+        public bool CanDecrypt(object keyIdentifier)
+        {
+            return Crypto.CanDecrypt(keyIdentifier);
+        }
+    }
+}

--- a/Rock.Encryption/Async/SynchronousAsyncDecryptor.cs
+++ b/Rock.Encryption/Async/SynchronousAsyncDecryptor.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// An implementation of <see cref="IAsyncDecryptor"/> that delegates all functionality
+    /// to an instance of <see cref="IAsyncDecryptor"/>. All tasks returned by its methods are
+    /// guaranteed to be already completed or faulted.
+    /// </summary>
+    public sealed class SynchronousAsyncDecryptor : IAsyncDecryptor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SynchronousAsyncDecryptor"/> class.
+        /// </summary>
+        /// <param name="decryptor">
+        /// The instance of <see cref="IDecryptor"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncDecryptor"/>.
+        /// </param>
+        public SynchronousAsyncDecryptor(IDecryptor decryptor)
+        {
+            Decryptor = decryptor;
+        }
+
+        /// <summary>
+        /// Gets the instance of <see cref="IDecryptor"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncDecryptor"/>.
+        /// </summary>
+        public IDecryptor Decryptor { get; }
+
+        /// <summary>
+        /// Synchronously decrypts the specified cipher text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>A completed task whose result represents the decrypted value as a string.</returns>
+        public Task<string> DecryptAsync(string cipherText)
+        {
+            var completion = new TaskCompletionSource<string>();
+            try
+            {
+                completion.SetResult(Decryptor.Decrypt(cipherText));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously decrypts the specified cipher text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>A completed task whose result represents the decrypted value as a byte array.</returns>
+        public Task<byte[]> DecryptAsync(byte[] cipherText)
+        {
+            var completion = new TaskCompletionSource<byte[]>();
+            try
+            {
+                completion.SetResult(Decryptor.Decrypt(cipherText));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+    }
+}

--- a/Rock.Encryption/Async/SynchronousAsyncEncryptor.cs
+++ b/Rock.Encryption/Async/SynchronousAsyncEncryptor.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Async
+{
+    /// <summary>
+    /// An implementation of <see cref="IAsyncEncryptor"/> that delegates all functionality
+    /// to an instance of <see cref="IEncryptor"/>. All tasks returned by its methods are
+    /// guaranteed to be already completed or faulted.
+    /// </summary>
+    public sealed class SynchronousAsyncEncryptor : IAsyncEncryptor
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SynchronousAsyncEncryptor"/> class.
+        /// </summary>
+        /// <param name="encryptor">
+        /// The instance of <see cref="IEncryptor"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncEncryptor"/>.
+        /// </param>
+        public SynchronousAsyncEncryptor(IEncryptor encryptor)
+        {
+            Encryptor = encryptor;
+        }
+
+        /// <summary>
+        /// Gets the instance of <see cref="IEncryptor"/> that performs the actual work
+        /// done by the methods of this instance of <see cref="SynchronousAsyncEncryptor"/>.
+        /// </summary>
+        public IEncryptor Encryptor { get; }
+
+        /// <summary>
+        /// Synchronously encrypts the specified plain text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>A completed task whose result represents the encrypted value as a string.</returns>
+        public Task<string> EncryptAsync(string plainText)
+        {
+            var completion = new TaskCompletionSource<string>();
+            try
+            {
+                completion.SetResult(Encryptor.Encrypt(plainText));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+
+        /// <summary>
+        /// Synchronously encrypts the specified plain text.
+        /// <para>The <see cref="Task{TResult}"/> returned by this method is guaranteed
+        /// to be either completed or faulted.</para>
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>A completed task whose result represents the encrypted value as a byte array.</returns>
+        public Task<byte[]> EncryptAsync(byte[] plainText)
+        {
+            var completion = new TaskCompletionSource<byte[]>();
+            try
+            {
+                completion.SetResult(Encryptor.Encrypt(plainText));
+            }
+            catch (Exception ex)
+            {
+                completion.SetException(ex);
+            }
+            return completion.Task;
+        }
+    }
+}

--- a/Rock.Encryption/Crypto.cs
+++ b/Rock.Encryption/Crypto.cs
@@ -5,6 +5,8 @@ using Microsoft.Extensions.Configuration;
 using RockLib.Encryption.Configuration;
 using RockLib.Configuration;
 using RockLib.Immutable;
+using RockLib.Encryption.Async;
+using System.Threading.Tasks;
 #else
 using Rock.Encryption.Configuration;
 using Rock.Immutable;
@@ -189,6 +191,150 @@ namespace Rock.Encryption
         {
             return Current.GetDecryptor(keyIdentifier);
         }
+
+#if ROCKLIB
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>The encrypted value as a string.</returns>
+        public static Task<string> EncryptAsync(string plainText)
+        {
+            return EncryptAsync(plainText, null);
+        }
+
+        /// <summary>
+        /// Asynchronously wncrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>The encrypted value as a string.</returns>
+        public static Task<string> EncryptAsync(string plainText, object keyIdentifier)
+        {
+            return Current.AsAsync().EncryptAsync(plainText, keyIdentifier);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>The decrypted value as a string.</returns>
+        public static Task<string> DecryptAsync(string cipherText)
+        {
+            return DecryptAsync(cipherText, null);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>The decrypted value as a string.</returns>
+        public static Task<string> DecryptAsync(string cipherText, object keyIdentifier)
+        {
+            return Current.AsAsync().DecryptAsync(cipherText, keyIdentifier);
+        }
+
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <returns>The encrypted value as a byte array.</returns>
+        public static Task<byte[]> EncryptAsync(byte[] plainText)
+        {
+            return EncryptAsync(plainText, null);
+        }
+
+        /// <summary>
+        /// Asynchronously encrypts the specified plain text.
+        /// </summary>
+        /// <param name="plainText">The plain text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>The encrypted value as a byte array.</returns>
+        public static Task<byte[]> EncryptAsync(byte[] plainText, object keyIdentifier)
+        {
+            return Current.AsAsync().EncryptAsync(plainText, keyIdentifier);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <returns>The decrypted value as a byte array.</returns>
+        public static Task<byte[]> DecryptAsync(byte[] cipherText)
+        {
+            return DecryptAsync(cipherText, null);
+        }
+
+        /// <summary>
+        /// Asynchronously decrypts the specified cipher text.
+        /// </summary>
+        /// <param name="cipherText">The cipher text.</param>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>The decrypted value as a byte array.</returns>
+        public static Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier)
+        {
+            return Current.AsAsync().DecryptAsync(cipherText, keyIdentifier);
+        }
+
+        /// <summary>
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided encrypt key.
+        /// </summary>
+        /// <returns>An object that can be used for encryption operations.</returns>
+        public static Task<IAsyncEncryptor> GetEncryptorAsync()
+        {
+            return GetEncryptorAsync(null);
+        }
+
+        /// <summary>
+        /// Gets an instance of <see cref="IAsyncEncryptor"/> for the provided encrypt key.
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>An object that can be used for encryption operations.</returns>
+        public static Task<IAsyncEncryptor> GetEncryptorAsync(object keyIdentifier)
+        {
+            return Current.AsAsync().GetEncryptorAsync(keyIdentifier);
+        }
+
+        /// <summary>
+        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
+        /// encrypt key.
+        /// </summary>
+        /// <returns>An object that can be used for decryption operations.</returns>
+        public static Task<IAsyncDecryptor> GetDecryptorAsync()
+        {
+            return GetDecryptorAsync(null);
+        }
+
+        /// <summary>
+        /// Asynchronously gets an instance of <see cref="IAsyncDecryptor"/> for the provided
+        /// encrypt key.
+        /// </summary>
+        /// <param name="keyIdentifier">
+        /// An implementation-specific object used to identify the key for this
+        /// encryption operation.
+        /// </param>
+        /// <returns>An object that can be used for decryption operations.</returns>
+        public static Task<IAsyncDecryptor> GetDecryptorAsync(object keyIdentifier)
+        {
+            return Current.AsAsync().GetDecryptorAsync(keyIdentifier);
+        }
+#endif
 
         private static ICrypto GetDefaultCrypto()
         {

--- a/RockLib.Encryption.Tests/Async/AsAsyncExtensionTests.cs
+++ b/RockLib.Encryption.Tests/Async/AsAsyncExtensionTests.cs
@@ -1,0 +1,73 @@
+﻿using Moq;
+using NUnit.Framework;
+using RockLib.Encryption.Async;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RockLib.Encryption.Tests.Async
+{
+    [TestFixture]
+    public class AsAsyncExtensionTests
+    {
+        [Test]
+        public void AsAsync_GivenAnObjectThatImplementsIAsyncCryptoTheSameObjectIsReturned()
+        {
+            var crypto = new TestCrypto();
+
+            var asyncCrypto = crypto.AsAsync();
+
+            Assert.That(asyncCrypto, Is.SameAs(crypto));
+        }
+
+        [Test]
+        public void AsAsync_GivenAnObjectThatDoesNotImplementsIAsyncCryptoASynchronousAsyncCryptoIsReturned()
+        {
+            var crypto = new Mock<ICrypto>().Object;
+
+            var asyncCrypto = crypto.AsAsync();
+
+            Assert.That(asyncCrypto, Is.InstanceOf<SynchronousAsyncCrypto>());
+        }
+
+        [Test]
+        public void AsAsync_GivenAnObjectThatDoesNotImplementsIAsyncCryptoTheSynchronousAsyncCryptoUsesTheOriginalICrypto()
+        {
+            var crypto = new Mock<ICrypto>().Object;
+
+            var asyncCrypto = (SynchronousAsyncCrypto)crypto.AsAsync();
+
+            Assert.That(asyncCrypto.Crypto, Is.SameAs(crypto));
+        }
+
+        [Test]
+        public void AsAsync_MultipleCallsWithTheSameObjectThatDoesNotImplementIAsyncCryptoReturnTheSameObjectEachTime()
+        {
+            var crypto = new Mock<ICrypto>().Object;
+
+            var asyncCrypto1 = crypto.AsAsync();
+            var asyncCrypto2 = crypto.AsAsync();
+
+            Assert.That(asyncCrypto1, Is.SameAs(asyncCrypto2));
+        }
+
+        private class TestCrypto : ICrypto, IAsyncCrypto
+        {
+            public bool CanDecrypt(object keyIdentifier) => throw new NotImplementedException();
+            public bool CanEncrypt(object keyIdentifier) => throw new NotImplementedException();
+            public string Decrypt(string cipherText, object keyIdentifier) => throw new NotImplementedException();
+            public byte[] Decrypt(byte[] cipherText, object keyIdentifier) => throw new NotImplementedException();
+            public Task<string> DecryptAsync(string cipherText, object keyIdentifier) => throw new NotImplementedException();
+            public Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier) => throw new NotImplementedException();
+            public string Encrypt(string plainText, object keyIdentifier) => throw new NotImplementedException();
+            public byte[] Encrypt(byte[] plainText, object keyIdentifier) => throw new NotImplementedException();
+            public Task<string> EncryptAsync(string plainText, object keyIdentifier) => throw new NotImplementedException();
+            public Task<byte[]> EncryptAsync(byte[] plainText, object keyIdentifier) => throw new NotImplementedException();
+            public IDecryptor GetDecryptor(object keyIdentifier) => throw new NotImplementedException();
+            public Task<IAsyncDecryptor> GetDecryptorAsync(object keyIdentifier) => throw new NotImplementedException();
+            public IEncryptor GetEncryptor(object keyIdentifier) => throw new NotImplementedException();
+            public Task<IAsyncEncryptor> GetEncryptorAsync(object keyIdentifier) => throw new NotImplementedException();
+        }
+    }
+}

--- a/RockLib.Encryption.Tests/Async/SynchronousAsyncCryptoTests.cs
+++ b/RockLib.Encryption.Tests/Async/SynchronousAsyncCryptoTests.cs
@@ -1,0 +1,240 @@
+﻿using Moq;
+using NUnit.Framework;
+using RockLib.Encryption.Async;
+using System.Text;
+
+namespace RockLib.Encryption.Tests.Async
+{
+    [TestFixture]
+    public class SynchronousAsyncCryptoTests
+    {
+        private Mock<ICrypto> _cryptoMock;
+        private IEncryptor _encryptor;
+        private IDecryptor _decryptor;
+
+        private void Setup(string cryptoId)
+        {
+            _cryptoMock = new Mock<ICrypto>();
+            _encryptor = new Mock<IEncryptor>().Object;
+            _decryptor = new Mock<IDecryptor>().Object;
+
+            _cryptoMock.Setup(f => f.CanEncrypt(cryptoId)).Returns(true);
+            _cryptoMock.Setup(f => f.CanEncrypt(It.Is<string>(s => s != cryptoId))).Returns(false);
+            _cryptoMock.Setup(f => f.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns($"EncryptedString : {cryptoId}");
+            _cryptoMock.Setup(f => f.Encrypt(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(Encoding.UTF8.GetBytes(cryptoId));
+            _cryptoMock.Setup(f => f.GetEncryptor(cryptoId)).Returns(_encryptor);
+
+            _cryptoMock.Setup(f => f.CanDecrypt(cryptoId)).Returns(true);
+            _cryptoMock.Setup(f => f.CanDecrypt(It.Is<string>(s => s != cryptoId))).Returns(false);
+            _cryptoMock.Setup(f => f.Decrypt(It.IsAny<string>(), It.IsAny<string>())).Returns($"DecryptedString : {cryptoId}");
+            _cryptoMock.Setup(f => f.Decrypt(It.IsAny<byte[]>(), It.IsAny<string>())).Returns(Encoding.UTF8.GetBytes(cryptoId));
+            _cryptoMock.Setup(f => f.GetDecryptor(cryptoId)).Returns(_decryptor);
+        }
+
+        [Test]
+        public void Crypto_IsTheSameInstancePassedToTheConstructor()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            Assert.That(asyncCrypto.Crypto, Is.SameAs(_cryptoMock.Object));
+        }
+
+        [Test]
+        public void EncryptAsync_string_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptTask = asyncCrypto.EncryptAsync("stuff", "foo");
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void EncryptAsync_string_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encrypted = asyncCrypto.EncryptAsync("stuff", "foo").Result;
+
+            Assert.That(encrypted, Is.EqualTo("EncryptedString : foo"));
+        }
+
+        [Test]
+        public void EncryptAsync_bytearray_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptTask = asyncCrypto.EncryptAsync(new byte[0], "foo");
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void EncryptAsync_bytearray_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encrypted = asyncCrypto.EncryptAsync(new byte[0], "foo").Result;
+
+            Assert.That(encrypted, Is.EqualTo(Encoding.UTF8.GetBytes("foo")));
+        }
+
+        [Test]
+        public void DecryptAsync_string_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptTask = asyncCrypto.DecryptAsync("stuff", "foo");
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void DecryptAsync_string_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encrypted = asyncCrypto.DecryptAsync("stuff", "foo").Result;
+
+            Assert.That(encrypted, Is.EqualTo("DecryptedString : foo"));
+        }
+
+        [Test]
+        public void DecryptAsync_bytearray_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptTask = asyncCrypto.DecryptAsync(new byte[0], "foo");
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void DecryptAsync_bytearray_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encrypted = asyncCrypto.DecryptAsync(new byte[0], "foo").Result;
+
+            Assert.That(encrypted, Is.EqualTo(Encoding.UTF8.GetBytes("foo")));
+        }
+
+        [Test]
+        public void GetEncryptorAsync_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptorTask = asyncCrypto.GetEncryptorAsync("foo");
+
+            Assert.That(encryptorTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void GetEncryptorAsync_ReturnsASynchronousAsyncEncryptor()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptor = asyncCrypto.GetEncryptorAsync("foo").Result;
+
+            Assert.That(encryptor, Is.InstanceOf<SynchronousAsyncEncryptor>());
+        }
+
+        [Test]
+        public void GetEncryptorAsync_ReturnsASynchronousAsyncEncryptorWhoseEncryptorIsTheOneReturnedByACallToTheCryptoGetEncryptorMethod()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var encryptor = (SynchronousAsyncEncryptor)asyncCrypto.GetEncryptorAsync("foo").Result;
+
+            Assert.That(encryptor.Encryptor, Is.SameAs(_encryptor));
+        }
+
+        [Test]
+        public void GetDecryptorAsync_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var decryptorTask = asyncCrypto.GetDecryptorAsync("foo");
+
+            Assert.That(decryptorTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void GetDecryptorAsync_ReturnsASynchronousAsyncDecryptor()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var decryptor = asyncCrypto.GetDecryptorAsync("foo").Result;
+
+            Assert.That(decryptor, Is.InstanceOf<SynchronousAsyncDecryptor>());
+        }
+
+        [Test]
+        public void GetDecryptorAsync_ReturnsASynchronousAsyncDecryptorWhoseDecryptorIsTheOneReturnedByACallToTheCryptoGetDecryptorMethod()
+        {
+            Setup("foo");
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            var decryptor = (SynchronousAsyncDecryptor)asyncCrypto.GetDecryptorAsync("foo").Result;
+
+            Assert.That(decryptor.Decryptor, Is.SameAs(_decryptor));
+        }
+
+        [Test]
+        public void CanEncrypt_ReturnsTheSameThingAsACallToCryptoCanEncrypt()
+        {
+            Setup("foo");
+
+            Assume.That(_cryptoMock.Object.CanEncrypt("foo"), Is.True);
+            Assume.That(_cryptoMock.Object.CanEncrypt("bar"), Is.False);
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            Assert.That(asyncCrypto.CanEncrypt("foo"), Is.True);
+            Assert.That(asyncCrypto.CanEncrypt("bar"), Is.False);
+        }
+
+        [Test]
+        public void CanDecrypt_ReturnsTheSameThingAsACallToCryptoCanDecrypt()
+        {
+            Setup("foo");
+
+            Assume.That(_cryptoMock.Object.CanDecrypt("foo"), Is.True);
+            Assume.That(_cryptoMock.Object.CanDecrypt("bar"), Is.False);
+
+            var asyncCrypto = new SynchronousAsyncCrypto(_cryptoMock.Object);
+
+            Assert.That(asyncCrypto.CanDecrypt("foo"), Is.True);
+            Assert.That(asyncCrypto.CanDecrypt("bar"), Is.False);
+        }
+    }
+}

--- a/RockLib.Encryption.Tests/Async/SynchronousAsyncDecryptorTests.cs
+++ b/RockLib.Encryption.Tests/Async/SynchronousAsyncDecryptorTests.cs
@@ -1,0 +1,71 @@
+﻿using Moq;
+using NUnit.Framework;
+using RockLib.Encryption;
+using RockLib.Encryption.Async;
+using System.Text;
+
+namespace RockLib.Decryption.Tests.Async
+{
+    [TestFixture]
+    public class SynchronousAsyncDecryptorTests
+    {
+        private Mock<IDecryptor> _decryptorMock;
+
+        private void Setup(string cryptoId)
+        {
+            _decryptorMock = new Mock<IDecryptor>();
+
+            _decryptorMock.Setup(f => f.Decrypt(It.IsAny<string>())).Returns($"DecryptedString : {cryptoId}");
+            _decryptorMock.Setup(f => f.Decrypt(It.IsAny<byte[]>())).Returns(Encoding.UTF8.GetBytes(cryptoId));
+        }
+
+
+        [Test]
+        public void DecryptAsync_string_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncDecryptor = new SynchronousAsyncDecryptor(_decryptorMock.Object);
+
+            var decryptTask = asyncDecryptor.DecryptAsync("stuff");
+
+            Assert.That(decryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void DecryptAsync_string_ReturnsTheResultReturnedByCryptoDecrypt()
+        {
+            Setup("foo");
+
+            var asyncDecryptor = new SynchronousAsyncDecryptor(_decryptorMock.Object);
+
+            var decrypted = asyncDecryptor.DecryptAsync("stuff").Result;
+
+            Assert.That(decrypted, Is.EqualTo("DecryptedString : foo"));
+        }
+
+        [Test]
+        public void DecryptAsync_bytearray_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncDecryptor = new SynchronousAsyncDecryptor(_decryptorMock.Object);
+
+            var decryptTask = asyncDecryptor.DecryptAsync(new byte[0]);
+
+            Assert.That(decryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void DecryptAsync_bytearray_ReturnsTheResultReturnedByCryptoDecrypt()
+        {
+            Setup("foo");
+
+            var asyncDecryptor = new SynchronousAsyncDecryptor(_decryptorMock.Object);
+
+            var decrypted = asyncDecryptor.DecryptAsync(new byte[0]).Result;
+
+            Assert.That(decrypted, Is.EqualTo(Encoding.UTF8.GetBytes("foo")));
+        }
+    }
+}

--- a/RockLib.Encryption.Tests/Async/SynchronousAsyncEncryptorTests.cs
+++ b/RockLib.Encryption.Tests/Async/SynchronousAsyncEncryptorTests.cs
@@ -1,0 +1,70 @@
+﻿using Moq;
+using NUnit.Framework;
+using RockLib.Encryption.Async;
+using System.Text;
+
+namespace RockLib.Encryption.Tests.Async
+{
+    [TestFixture]
+    public class SynchronousAsyncEncryptorTests
+    {
+        private Mock<IEncryptor> _encryptorMock;
+
+        private void Setup(string cryptoId)
+        {
+            _encryptorMock = new Mock<IEncryptor>();
+
+            _encryptorMock.Setup(f => f.Encrypt(It.IsAny<string>())).Returns($"EncryptedString : {cryptoId}");
+            _encryptorMock.Setup(f => f.Encrypt(It.IsAny<byte[]>())).Returns(Encoding.UTF8.GetBytes(cryptoId));
+        }
+
+
+        [Test]
+        public void EncryptAsync_string_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncEncryptor = new SynchronousAsyncEncryptor(_encryptorMock.Object);
+
+            var encryptTask = asyncEncryptor.EncryptAsync("stuff");
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void EncryptAsync_string_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncEncryptor = new SynchronousAsyncEncryptor(_encryptorMock.Object);
+
+            var encrypted = asyncEncryptor.EncryptAsync("stuff").Result;
+
+            Assert.That(encrypted, Is.EqualTo("EncryptedString : foo"));
+        }
+
+        [Test]
+        public void EncryptAsync_bytearray_ReturnsACompletedTask()
+        {
+            Setup("foo");
+
+            var asyncEncryptor = new SynchronousAsyncEncryptor(_encryptorMock.Object);
+
+            var encryptTask = asyncEncryptor.EncryptAsync(new byte[0]);
+
+            Assert.That(encryptTask.IsCompleted, Is.True);
+        }
+
+        [Test]
+        public void EncryptAsync_bytearray_ReturnsTheResultReturnedByCryptoEncrypt()
+        {
+            Setup("foo");
+
+            var asyncEncryptor = new SynchronousAsyncEncryptor(_encryptorMock.Object);
+
+            var encrypted = asyncEncryptor.EncryptAsync(new byte[0]).Result;
+
+            Assert.That(encrypted, Is.EqualTo(Encoding.UTF8.GetBytes("foo")));
+        }
+    }
+}

--- a/RockLib.Encryption.Tests/CryptoTests.cs
+++ b/RockLib.Encryption.Tests/CryptoTests.cs
@@ -7,6 +7,8 @@ using NUnit.Framework;
 using RockLib.Configuration;
 using RockLib.Encryption.Symmetric;
 using RockLib.Immutable;
+using RockLib.Encryption.Async;
+using System.Threading.Tasks;
 
 namespace RockLib.Encryption.Tests
 {
@@ -181,6 +183,218 @@ namespace RockLib.Encryption.Tests
             cryptoMock.Verify(cm => cm.Decrypt(It.Is<byte[]>(s => s == byteArrayToDecrypt), It.Is<object>(o => o == identifier)));
         }
 
+        [Test]
+        public void GetEncryptorAsyncGivenCurrentIsIAsyncCryptoCallsCryptoGetEncryptorAsync()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+            
+            var identifier = new object();
+
+            Crypto.GetEncryptorAsync().Wait();
+            Crypto.GetEncryptorAsync(identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.GetEncryptorAsync(null));
+            cryptoMock.Verify(cm => cm.GetEncryptorAsync(It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void GetEncryptorAsyncGivenCurrentIsNotIAsyncCryptoCallsCryptoGetEncryptor()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var identifier = new object();
+
+            Crypto.GetEncryptorAsync().Wait();
+            Crypto.GetEncryptorAsync(identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.GetEncryptor(null));
+            cryptoMock.Verify(cm => cm.GetEncryptor(It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void GetDecryptorAsyncGivenCurrentIsIAsyncCryptoCallsCryptoGetDecryptorAsync()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var identifier = new object();
+
+            Crypto.GetDecryptorAsync().Wait();
+            Crypto.GetDecryptorAsync(identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.GetDecryptorAsync(null));
+            cryptoMock.Verify(cm => cm.GetDecryptorAsync(It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void GetDecryptorAsyncGivenCurrentIsNotIAsyncCryptoCallsCryptoGetDecryptor()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var identifier = new object();
+
+            Crypto.GetDecryptorAsync().Wait();
+            Crypto.GetDecryptorAsync(identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.GetDecryptor(null));
+            cryptoMock.Verify(cm => cm.GetDecryptor(It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void EncryptAsyncByStringGivenCurrentIsIAsyncCryptoCallsCryptoEncryptAsyncByString()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var stringToEncrypt = "Something to encrypt";
+            var identifier = new object();
+
+            Crypto.EncryptAsync(stringToEncrypt).Wait();
+            Crypto.EncryptAsync(stringToEncrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.EncryptAsync(It.Is<string>(s => s == stringToEncrypt), null));
+            cryptoMock.Verify(cm => cm.EncryptAsync(It.Is<string>(s => s == stringToEncrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void EncryptAsyncByStringGivenCurrentIsNotIAsyncCryptoCallsCryptoEncryptByString()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var stringToEncrypt = "Something to encrypt";
+            var identifier = new object();
+
+            Crypto.EncryptAsync(stringToEncrypt).Wait();
+            Crypto.EncryptAsync(stringToEncrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.Encrypt(It.Is<string>(s => s == stringToEncrypt), null));
+            cryptoMock.Verify(cm => cm.Encrypt(It.Is<string>(s => s == stringToEncrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void EncryptAsyncByByteArrayGivenCurrentIsIAsyncCryptoCallsCryptoEncryptAsyncByByteArray()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var byteArrayToEncrypt = new byte[0];
+            var identifier = new object();
+
+            Crypto.EncryptAsync(byteArrayToEncrypt);
+            Crypto.EncryptAsync(byteArrayToEncrypt, identifier);
+
+            cryptoMock.Verify(cm => cm.EncryptAsync(It.Is<byte[]>(s => s == byteArrayToEncrypt), null));
+            cryptoMock.Verify(cm => cm.EncryptAsync(It.Is<byte[]>(s => s == byteArrayToEncrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void EncryptAsyncByByteArrayGivenCurrentIsNotIAsyncCryptoCallsCryptoEncryptByByteArray()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var byteArrayToEncrypt = new byte[0];
+            var identifier = new object();
+
+            Crypto.EncryptAsync(byteArrayToEncrypt);
+            Crypto.EncryptAsync(byteArrayToEncrypt, identifier);
+
+            cryptoMock.Verify(cm => cm.Encrypt(It.Is<byte[]>(s => s == byteArrayToEncrypt), null));
+            cryptoMock.Verify(cm => cm.Encrypt(It.Is<byte[]>(s => s == byteArrayToEncrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void DecryptAsyncByStringGivenCurrentIsIAsyncCryptoCallsCryptoDecryptAsyncByString()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var stringToDecrypt = "Something to encrypt";
+            var identifier = new object();
+
+            Crypto.DecryptAsync(stringToDecrypt).Wait();
+            Crypto.DecryptAsync(stringToDecrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.DecryptAsync(It.Is<string>(s => s == stringToDecrypt), null));
+            cryptoMock.Verify(cm => cm.DecryptAsync(It.Is<string>(s => s == stringToDecrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void DecryptAsyncByStringGivenCurrentIsNotIAsyncCryptoCallsCryptoDecryptByString()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var stringToDecrypt = "Something to encrypt";
+            var identifier = new object();
+
+            Crypto.DecryptAsync(stringToDecrypt).Wait();
+            Crypto.DecryptAsync(stringToDecrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.Decrypt(It.Is<string>(s => s == stringToDecrypt), null));
+            cryptoMock.Verify(cm => cm.Decrypt(It.Is<string>(s => s == stringToDecrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void DecryptAsyncByByteArrayGivenCurrentIsIAsyncCryptoCallsCryptoDecryptAsyncByByteArray()
+        {
+            var cryptoMock = new Mock<AbstractAsyncCrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var byteArrayToDecrypt = new byte[0];
+            var identifier = new object();
+
+            Crypto.DecryptAsync(byteArrayToDecrypt).Wait();
+            Crypto.DecryptAsync(byteArrayToDecrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.DecryptAsync(It.Is<byte[]>(s => s == byteArrayToDecrypt), null));
+            cryptoMock.Verify(cm => cm.DecryptAsync(It.Is<byte[]>(s => s == byteArrayToDecrypt), It.Is<object>(o => o == identifier)));
+        }
+
+        [Test]
+        public void DecryptAsyncByByteArrayGivenCurrentIsNotIAsyncCryptoCallsCryptoDecryptByByteArray()
+        {
+            var cryptoMock = new Mock<ICrypto>();
+
+            ResetCrypto();
+            Crypto.SetCurrent(cryptoMock.Object);
+
+            var byteArrayToDecrypt = new byte[0];
+            var identifier = new object();
+
+            Crypto.DecryptAsync(byteArrayToDecrypt).Wait();
+            Crypto.DecryptAsync(byteArrayToDecrypt, identifier).Wait();
+
+            cryptoMock.Verify(cm => cm.Decrypt(It.Is<byte[]>(s => s == byteArrayToDecrypt), null));
+            cryptoMock.Verify(cm => cm.Decrypt(It.Is<byte[]>(s => s == byteArrayToDecrypt), It.Is<object>(o => o == identifier)));
+        }
+
         private static void ResetConfig()
         {
             var rootField = typeof(Config).GetField("_root", BindingFlags.NonPublic | BindingFlags.Static);
@@ -192,6 +406,24 @@ namespace RockLib.Encryption.Tests
             var currentField = typeof(Crypto).GetField("_current", BindingFlags.NonPublic | BindingFlags.Static);
             var current = (Semimutable<ICrypto>)currentField.GetValue(null);
             current.GetUnlockValueMethod().Invoke(current, null);
+        }
+
+        public abstract class AbstractAsyncCrypto : ICrypto, IAsyncCrypto
+        {
+            public abstract bool CanDecrypt(object keyIdentifier);
+            public abstract bool CanEncrypt(object keyIdentifier);
+            public abstract string Decrypt(string cipherText, object keyIdentifier);
+            public abstract byte[] Decrypt(byte[] cipherText, object keyIdentifier);
+            public abstract Task<string> DecryptAsync(string cipherText, object keyIdentifier);
+            public abstract Task<byte[]> DecryptAsync(byte[] cipherText, object keyIdentifier);
+            public abstract string Encrypt(string plainText, object keyIdentifier);
+            public abstract byte[] Encrypt(byte[] plainText, object keyIdentifier);
+            public abstract Task<string> EncryptAsync(string plainText, object keyIdentifier);
+            public abstract Task<byte[]> EncryptAsync(byte[] plainText, object keyIdentifier);
+            public abstract IDecryptor GetDecryptor(object keyIdentifier);
+            public abstract Task<IAsyncDecryptor> GetDecryptorAsync(object keyIdentifier);
+            public abstract IEncryptor GetEncryptor(object keyIdentifier);
+            public abstract Task<IAsyncEncryptor> GetEncryptorAsync(object keyIdentifier);
         }
     }
 }


### PR DESCRIPTION
This pull request adds an asynchronous API to the RockLib package.
- Introduces three new interfaces that mirror existing interfaces:
  - `IAsyncCrypto` - `ICrypto`
  - `IAsyncEncryptor` - `IEncryptor`
  - `IAsyncDecryptor` - `IDecryptor`
- Includes synchronous implementations of the new interfaces: `SynchronousAsyncCrypto`, `SynchronousAsyncEncryptor`, and `SynchronousAsyncDecryptor`.
  - Each implementation takes an instance of its mirror interface as a constructor parameter.
    - E.g. `public SynchronousAsyncCrypto(ICrypto crypto)`
  - Each method returns a completed task with the result of calling its synchronous counterpart.
    - E.g. `SynchronousAsyncCrypto.EncryptAsync` calls `ICrypto.Encrypt` with the same parameters.
- Adds extension method: `IAsyncCrypto ToAsync(this ICrypto crypto)`.
  - If the instance of `ICrypto` passed to the method implements `IAsyncCrypto`, it is cast and returned.
  - If the instance of `ICrypto` passed to the method does *not* implement `IAsyncCrypto`, then an instance of `SynchronousAsyncCrypto` is returned, passing the `ICrypto` to its constructor.
    - Note that multiple calls to the `ToAsync` extension method with the same instance of `ICrypto` will return the same instance of `SynchronousAsyncCrypto`.
- Adds asynchronous methods in the `Crypto` static class.
  - Each method calls the `AsAsync` extension method on the `Current` property and delegates functionality to the resulting `IAsyncCrypto` object.